### PR TITLE
Formatting SSH proxy config for success.

### DIFF
--- a/development/intel_only/ssh_proxy_config
+++ b/development/intel_only/ssh_proxy_config
@@ -1,1 +1,2 @@
-Host * ProxyCommand  connect -S proxy-us.intel.com:1080 %h %p
+Host *
+    ProxyCommand  connect -S proxy-us.intel.com:1080 %h %p


### PR DESCRIPTION
The proxy config will not work in a single line. Adding a new line and tab for valid proxy configuration formatting.