### PR TITLE
Adding ssh configuration for TeamForge

### DIFF
--- a/development/intel_only/ssh_proxy_config
+++ b/development/intel_only/ssh_proxy_config
@@ -1,2 +1,9 @@
-Host *
+# For GitHub access
+Host github.com
     ProxyCommand  connect -S proxy-us.intel.com:1080 %h %p
+
+# For TeamForge access
+Host git.*.devtools.intel.com
+    ForwardAgent no
+    ForwardX11 no
+    HostkeyAlgorithms +ssh-dss


### PR DESCRIPTION
Changing existing proxy exclusively for GitHub SSH access.
Adding additional config for TeamForge SSH access.